### PR TITLE
fix chef 12 error add name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name              "zypper"
 maintainer        "The App Business"
 maintainer_email  "engineering@theappbusiness.com"
 license           "Apache 2.0"


### PR DESCRIPTION
Fix the following exception

```
DEBUG: Chef::Exceptions::MetadataNotValid: Cookbook loaded at path(s) [/tmp/vagrant-chef-3/chef-solo-1/cookbooks/zypper] has invalid metadata: The `name' attribute is required in cookbook metadata
```
